### PR TITLE
Local context lookup

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/util/concurrent/ThreadContext.java
+++ b/server/src/main/java/org/elasticsearch/common/util/concurrent/ThreadContext.java
@@ -469,6 +469,10 @@ public final class ThreadContext implements Writeable {
         threadLocal.set(threadLocal.get().putTransient(key, value));
     }
 
+    public void removeTransient(String key) {
+        threadLocal.set(threadLocal.get().removeTransient(key));
+    }
+
     /**
      * Returns a transient header object or <code>null</code> if there is no header for the given key
      */
@@ -736,6 +740,12 @@ public final class ThreadContext implements Writeable {
         private ThreadContextStruct putTransient(String key, Object value) {
             Map<String, Object> newTransient = new HashMap<>(this.transientHeaders);
             putSingleHeader(key, value, newTransient);
+            return new ThreadContextStruct(requestHeaders, responseHeaders, newTransient, isSystemContext);
+        }
+
+        public ThreadContextStruct removeTransient(String key) {
+            Map<String, Object> newTransient = new HashMap<>(this.transientHeaders);
+            newTransient.remove(key);
             return new ThreadContextStruct(requestHeaders, responseHeaders, newTransient, isSystemContext);
         }
 

--- a/x-pack/plugin/apm-integration/src/main/java/org/elasticsearch/xpack/apm/APM.java
+++ b/x-pack/plugin/apm-integration/src/main/java/org/elasticsearch/xpack/apm/APM.java
@@ -33,6 +33,8 @@ import java.util.function.Supplier;
 public class APM extends Plugin implements NetworkPlugin {
     public static final Set<String> TRACE_HEADERS = Set.of(Task.TRACE_PARENT_HTTP_HEADER, Task.TRACE_STATE);
 
+    public static final String LOCAL_CONTEXT_PARENT = "apm.local.parent";
+
     private final SetOnce<APMTracer> tracer = new SetOnce<>();
     private final Settings settings;
 

--- a/x-pack/plugin/apm-integration/src/main/java/org/elasticsearch/xpack/apm/APMTracer.java
+++ b/x-pack/plugin/apm-integration/src/main/java/org/elasticsearch/xpack/apm/APMTracer.java
@@ -197,6 +197,8 @@ public class APMTracer extends AbstractLifecycleComponent implements org.elastic
 
             threadContext.putHeader(spanHeaders);
 
+            threadContext.removeTransient(LOCAL_CONTEXT_PARENT);
+
             threadContext.putTransient(LOCAL_CONTEXT_PARENT, context);
 
             // logGraphviz(span);


### PR DESCRIPTION
- pass parent context reference through a transient header
- had to allow removal of transient header to avoid overriding it.